### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module is meant for use with Terraform 0.12. If you haven't [upgraded](http
 Basic usage is as follows:
 ```hcl
 module "load_balancer" {
-  source       = "terraform-google-modules/lb/google"
+  source       = "GoogleCloudPlatform/lb/google"
   version      = "~> 2.0.0"
   region       = var.region
   name         = "load-balancer"


### PR DESCRIPTION
When I tried `terraform init` referencing usage section of README.md, I got the following error.

```
$ terraform init
...
Error: Module not found

Module "load_balancer" (from gce.tf:54) cannot be found in the module registry
at registry.terraform.io.
...
```

After fixing source parameter of the module, `terraform init` succeeded.