### PR TITLE
Fix name of output in readme

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -37,7 +37,7 @@ export GOOGLE_PROJECT=$(gcloud config get-value project)
 ## Test Load Balancer
 * Open the URL of the load balancer in your browser
 ```
-echo http://$(terraform output load_balancer_ip)
+echo http://$(terraform output load_balancer_default_ip)
 ```
 
 ## Cleanup Resources


### PR DESCRIPTION
The readme has the command, `echo http://$(terraform output load_balancer_ip)`.
The output name referenced in the command doesn't match the output name in outputs.tf. I've fixed this issue.