### PR TITLE
add support for multiple ports and injecting instances to the target_pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ Full functional examples are located in the [examples](./examples/) directory.
 | disable\_health\_check | Disables the health check on the target pool. | `bool` | `false` | no |
 | firewall\_project | Name of the project to create the firewall rule in. Useful for shared VPC. Default is var.project. | `string` | `""` | no |
 | health\_check | Health check to determine whether instances are responsive and able to do work | <pre>object({<br>    check_interval_sec  = number<br>    healthy_threshold   = number<br>    timeout_sec         = number<br>    unhealthy_threshold = number<br>    port                = number<br>    request_path        = string<br>    host                = string<br>  })</pre> | <pre>{<br>  "check_interval_sec": null,<br>  "healthy_threshold": null,<br>  "host": null,<br>  "port": null,<br>  "request_path": null,<br>  "timeout_sec": null,<br>  "unhealthy_threshold": null<br>}</pre> | no |
+| instances | List of instance self links to add to the target pool. | `list(string)` | `null` | no |
 | ip\_address | IP address of the external load balancer, if empty one will be assigned. | `any` | `null` | no |
 | ip\_protocol | The IP protocol for the frontend forwarding rule and firewall rule. TCP, UDP, ESP, AH, SCTP or ICMP. | `string` | `"TCP"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources. | `string` | n/a | yes |
 | network | Name of the network to create resources in. | `string` | `"default"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | `string` | `""` | no |
 | region | Region used for GCP resources. | `string` | n/a | yes |
-| service\_port | TCP port your service is listening on. | `number` | n/a | yes |
+| service\_ports | List of TCP ports your service is listening on. | `list(number)` | n/a | yes |
 | session\_affinity | How to distribute load. Options are `NONE`, `CLIENT_IP` and `CLIENT_IP_PROTO` | `string` | `"NONE"` | no |
 | target\_service\_accounts | List of target service accounts to allow traffic using firewall rule. | `list(string)` | `null` | no |
 | target\_tags | List of target tags to allow traffic using firewall rule. | `list(string)` | `null` | no |
@@ -74,7 +75,7 @@ Full functional examples are located in the [examples](./examples/) directory.
 
 | Name | Description |
 |------|-------------|
-| external\_ip | The external ip address of the forwarding rule. |
+| external\_ip | The external ip address of the forwarding rules. |
 | target\_pool | The `self_link` to the target pool resource created. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -61,11 +61,11 @@ module "managed_instance_group" {
 }
 
 module "load_balancer_default" {
-  name         = "basic-load-balancer-default"
-  source       = "../../"
-  region       = var.region
-  service_port = 80
-  network      = google_compute_network.network.name
+  name          = "basic-load-balancer-default"
+  source        = "../../"
+  region        = var.region
+  service_ports = [80]
+  network       = google_compute_network.network.name
 
   target_service_accounts = [google_service_account.instance-group.email]
 }
@@ -74,7 +74,7 @@ module "load_balancer_no_hc" {
   name                 = "basic-load-balancer-no-hc"
   source               = "../../"
   region               = var.region
-  service_port         = 80
+  service_ports        = [80]
   network              = google_compute_network.network.name
   disable_health_check = true
 
@@ -82,12 +82,12 @@ module "load_balancer_no_hc" {
 }
 
 module "load_balancer_custom_hc" {
-  name         = "basic-load-balancer-custom-hc"
-  source       = "../../"
-  region       = var.region
-  service_port = 8080
-  network      = google_compute_network.network.name
-  health_check = local.health_check
+  name          = "basic-load-balancer-custom-hc"
+  source        = "../../"
+  region        = var.region
+  service_ports = [8080]
+  network       = google_compute_network.network.name
+  health_check  = local.health_check
 
   target_service_accounts = [google_service_account.instance-group.email]
 }

--- a/main.tf
+++ b/main.tf
@@ -19,11 +19,12 @@ locals {
 }
 
 resource "google_compute_forwarding_rule" "default" {
+  count                 = length(var.service_ports)
   project               = var.project
-  name                  = var.name
+  name                  = "${var.name}-${var.service_ports[count.index]}"
   target                = google_compute_target_pool.default.self_link
   load_balancing_scheme = "EXTERNAL"
-  port_range            = var.service_port
+  port_range            = var.service_ports[count.index]
   region                = var.region
   ip_address            = var.ip_address
   ip_protocol           = var.ip_protocol
@@ -34,6 +35,7 @@ resource "google_compute_target_pool" "default" {
   name             = var.name
   region           = var.region
   session_affinity = var.session_affinity
+  instances        = var.instances
 
   health_checks = var.disable_health_check ? [] : [google_compute_http_health_check.default.0.self_link]
 }
@@ -48,7 +50,7 @@ resource "google_compute_http_health_check" "default" {
   timeout_sec         = var.health_check["timeout_sec"]
   unhealthy_threshold = var.health_check["unhealthy_threshold"]
 
-  port         = local.health_check_port == null ? var.service_port : local.health_check_port
+  port         = local.health_check_port == null ? var.service_ports[0] : local.health_check_port
   request_path = var.health_check["request_path"]
   host         = var.health_check["host"]
 }
@@ -60,7 +62,7 @@ resource "google_compute_firewall" "default-lb-fw" {
 
   allow {
     protocol = lower(var.ip_protocol)
-    ports    = [var.service_port]
+    ports    = var.service_ports
   }
 
   source_ranges = var.allowed_ips

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,6 +20,6 @@ output "target_pool" {
 }
 
 output "external_ip" {
-  description = "The external ip address of the forwarding rule."
-  value       = google_compute_forwarding_rule.default.ip_address
+  description = "The external ip address of the forwarding rules."
+  value       = google_compute_forwarding_rule.default[0].ip_address
 }

--- a/test/fixtures/basic/variables.tf
+++ b/test/fixtures/basic/variables.tf
@@ -15,7 +15,7 @@
  */
 
 variable "project_id" {
-  type        = "string"
+  type        = string
   description = "The project ID to deploy resources into"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,19 @@ variable "name" {
   description = "Name for the forwarding rule and prefix for supporting resources."
 }
 
-variable "service_port" {
-  type        = number
-  description = "TCP port your service is listening on."
+variable "service_ports" {
+  type        = list(number)
+  description = "List of TCP ports your service is listening on."
 }
 
 variable "target_tags" {
   description = "List of target tags to allow traffic using firewall rule."
+  type        = list(string)
+  default     = null
+}
+
+variable "instances" {
+  description = "List of instance self links to add to the target pool."
   type        = list(string)
   default     = null
 }


### PR DESCRIPTION
does what it says on the tin. 

changed input from number:`service_port` to list(number)`service_ports`  

umigs don't have a target_pools option, so added the ability to add instances to the target_pool.