### PR TITLE
Adds support for labels on forwarding rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ resource "google_compute_forwarding_rule" "default" {
   region                = var.region
   ip_address            = var.ip_address
   ip_protocol           = var.ip_protocol
+  labels                = var.labels
 }
 
 resource "google_compute_target_pool" "default" {

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,8 @@ locals {
 }
 
 resource "google_compute_forwarding_rule" "default" {
+  provider = google-beta
+
   project               = var.project
   name                  = var.name
   target                = google_compute_target_pool.default.self_link

--- a/variables.tf
+++ b/variables.tf
@@ -107,5 +107,10 @@ variable "allowed_ips" {
   description = "The IP address ranges which can access the load balancer."
   default     = ["0.0.0.0/0"]
   type        = list(string)
+}
 
+variable "labels" {
+  description = "The labels to attach to this load balancer's forwarding rule"
+  default     = {}
+  type        = map(string)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -22,6 +22,11 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.53, < 5.0"
     }
+
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 3.53, < 5.0"
+    }
   }
 
   provider_meta "google" {


### PR DESCRIPTION
Other resources in this module do not yet support labels.

Labels require the `google-beta` provider[1], which has some precedent in the terraform-google-lb-http module[2].

[1] https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule#labels
[2] https://github.com/terraform-google-modules/terraform-google-lb-http/blob/d98eb7c/versions.tf#L25